### PR TITLE
Change LEAF explorer to one on correct block chain

### DIFF
--- a/p2pool/bitcoin/networks.py
+++ b/p2pool/bitcoin/networks.py
@@ -816,9 +816,9 @@ nets = dict(
         CONF_FILE_FUNC=lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'LeafCoin') 
 		if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Leafcoin/') 
 		if platform.system() == 'Darwin' else os.path.expanduser('~/.leafcoin'), 'leafcoin.conf'),
-        BLOCK_EXPLORER_URL_PREFIX='http://cryptexplorer.com/block/',
-        ADDRESS_EXPLORER_URL_PREFIX='http://cryptexplorer.com/address/',
-        TX_EXPLORER_URL_PREFIX='http://cryptexplorer.com/tx/',
+        BLOCK_EXPLORER_URL_PREFIX='http://explorer.leafco.in/block/',
+        ADDRESS_EXPLORER_URL_PREFIX='http://explorer.leafco.in/address/',
+        TX_EXPLORER_URL_PREFIX='http://explorer.leafco.in/tx/',
         SANE_TARGET_RANGE=(2**256//1000000000 - 1, 2**256//1000 - 1),
         DUMB_SCRYPT_DIFF=2**16,
         DUST_THRESHOLD=0.03e8,


### PR DESCRIPTION
Change LEAF block chain explorer to one that is on correct block chain.

There was a required change - adding Kimoto's Gravity Well to Leafcoin, and it was applied at block 18818 (in "gravity fix - 3"), but not all updated - so there is a block chain fork.

Leafcoin source: https://github.com/leafcoin/leafcoin
More info: https://bitcointalk.org/index.php?topic=430091.0
