### PR TITLE
Update mooncoin.py

### DIFF
--- a/p2pool/bitcoin/networks/mooncoin.py
+++ b/p2pool/bitcoin/networks/mooncoin.py
@@ -20,9 +20,9 @@ POW_FUNC = lambda data: pack.IntType(256).unpack(__import__('ltc_scrypt').getPoW
 BLOCK_PERIOD = 90 # s
 SYMBOL = 'MOON'
 CONF_FILE_FUNC = lambda: os.path.join(os.path.join(os.environ['APPDATA'], 'MoonCoin') if platform.system() == 'Windows' else os.path.expanduser('~/Library/Application Support/Mooncoin/') if platform.system() == 'Darwin' else os.path.expanduser('~/.mooncoin'), 'mooncoin.conf')
-BLOCK_EXPLORER_URL_PREFIX = 'http://mooncoin.info/abe/block/'
-ADDRESS_EXPLORER_URL_PREFIX = 'http://mooncoin.info/abe/address/'
-TX_EXPLORER_URL_PREFIX = 'http://mooncoin.info/abe/tx/'
+BLOCK_EXPLORER_URL_PREFIX = 'http://moonchain.net/block/'
+ADDRESS_EXPLORER_URL_PREFIX = 'http://moonchain.net/address/'
+TX_EXPLORER_URL_PREFIX = 'http://moonchain.net/tx/'
 SANE_TARGET_RANGE = (2**256//1000000000 - 1, 2**256//1000 - 1)
 DUMB_SCRYPT_DIFF = 2**16
 DUST_THRESHOLD = 0.03e8


### PR DESCRIPTION
Changed URLs to the current Mooncoin block explorer, since mooncoin.info is down for several days.
